### PR TITLE
Add visibility toggle for puzzle tester

### DIFF
--- a/Assets/_Scenes/TestScenes/Julian/Puzzles/PuzzleTester.prefab
+++ b/Assets/_Scenes/TestScenes/Julian/Puzzles/PuzzleTester.prefab
@@ -30,7 +30,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5562036789717180523
 MonoBehaviour:
@@ -46,5 +46,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _GameEventDispatcher: {fileID: 11400000, guid: 2db1ab98fd921ae4fa6da5cb991c6934, type: 2}
   _PuzzleDictionary: {fileID: 11400000, guid: bc519dd8a9aaf0440a3a5bbfb743ed0a, type: 2}
-  _TriggerKey: terminal-a
-  _PuzzleLevel: {fileID: 852967454531116800, guid: 64204a479b99f76468ab0a11d01b238b, type: 3}
+  _TriggerKey: powerterminal
+  _PuzzleLevel: {fileID: 852967454531116800, guid: 58f1bf9cd249781498aad41316a07467, type: 3}
+  _KeyCode: 102
+  _Modifier: 306

--- a/Assets/_Scenes/TestScenes/Julian/Scripts/Puzzles/PuzzleTester.cs
+++ b/Assets/_Scenes/TestScenes/Julian/Scripts/Puzzles/PuzzleTester.cs
@@ -1,8 +1,8 @@
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using Puzzles;
 using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
 
 public class PuzzleTester : MonoBehaviour
 {
@@ -12,8 +12,33 @@ public class PuzzleTester : MonoBehaviour
     public string     _TriggerKey;
     public PuzzleBase _PuzzleLevel;
 
+    public  KeyCode _ToggleKey = KeyCode.F;
+    public  KeyCode _Modifier = KeyCode.LeftControl;
+    
+    private bool       _isShowing = true;
+    private KeyControl _toggleKeyControl;
+    
+    private void Awake()
+    {
+        _toggleKeyControl      = Keyboard.current.FindKeyOnCurrentKeyboardLayout(_ToggleKey.ToString());
+        
+        _isShowing = Application.isEditor;
+    }
+
+    private void Update()
+    {
+        if (Keyboard.current.ctrlKey.isPressed && _toggleKeyControl.wasPressedThisFrame)
+        {
+            _isShowing = !_isShowing;
+        }    
+    }
+    
     private void OnGUI()
     {
+        if (!_isShowing)
+            return;
+            
+            
         if (GUILayout.Button("Test Specific Puzzle"))
         {
             var showPuzzleArgs = new ShowPuzzleArgs


### PR DESCRIPTION
Add visibility toggle for puzzle tester. 

Now it is on by default in the editor, and off by default otherwise!
Use` Ctrl + F` to toggle tester button visibility